### PR TITLE
Bugfix: wrong declaration of read_vti when building without VTK

### DIFF
--- a/src/RW.cpp
+++ b/src/RW.cpp
@@ -321,7 +321,7 @@ int RW::read_vti(std::vector<size_t> &dims, std::vector<vec> &vfield, vector<poi
 }
 
 #else
-int RW::read_vti(std::vector<size_t> &dims, std::vector<vec> &vfield, std::string filename) {
+int RW::read_vti(std::vector<size_t> &dims, std::vector<vec> &vfield, vector<point> &points, std::string filename) {
     printf("VTK not available. Please reinstall with VTK libraries!\n");
     exit(1);
 }


### PR DESCRIPTION
Dear Dr. Bhatia,

When trying to compile your code without VTK present on my computer, I found that there is a wrong declaration of the function read_vti in RW.cpp.

Thanks for publishing your code, your method is very interesting and I hope to try it out soon.

Best regards,
Lukas Unglehrt

--
Technical University of Munich